### PR TITLE
adding depth_registered_filtered injection

### DIFF
--- a/launch/includes/depth.launch.xml
+++ b/launch/includes/depth.launch.xml
@@ -35,7 +35,7 @@
     <remap from="image_raw" to="$(arg depth)/image_raw" />
     <remap from="image"     to="$(arg depth)/image" />
   </node>
-  
+
   <!-- XYZ point cloud (optional, disable if publishing XYZRGB instead) -->
   <node if="$(arg points_xyz)"
         pkg="nodelet" type="nodelet" name="$(arg depth)_points"

--- a/launch/includes/depth_registered.launch.xml
+++ b/launch/includes/depth_registered.launch.xml
@@ -71,5 +71,5 @@
       <remap from="depth_registered/points"     to="$(arg depth_registered)/points" />
     </node>
   </group>
-  
+
 </launch>

--- a/launch/includes/depth_registered.launch.xml
+++ b/launch/includes/depth_registered.launch.xml
@@ -19,6 +19,10 @@
   <!-- For distinguishing multiple register/XYZRGB nodelets. Default fails if rgb
        or depth contains a namespace. -->
   <arg name="suffix" default="$(arg depth)_$(arg rgb)" />
+  <!-- For filtering depth images, set depth_registered_filtered to the
+       filtered depth image topic -->
+  <arg name="depth_registered_filtered" default="depth_registered" />
+
 
   <!-- Registration nodelet, projecting depth to RGB camera -->
   <group if="$(arg sw_registered_processing)">
@@ -39,7 +43,7 @@
       <!-- Explicit topic remappings, shouldn't need all of these -->
       <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color" />
       <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />
-      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/sw_registered/image_rect_raw" />
+      <remap from="depth_registered/image_rect" to="$(arg depth_registered_filtered)/sw_registered/image_rect_raw" />
       <remap from="depth_registered/points"     to="$(arg depth_registered)/points" />
     </node>
   </group>
@@ -63,7 +67,7 @@
       <!-- Explicit topic remappings, shouldn't need all of these -->
       <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color" />
       <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />
-      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/hw_registered/image_rect_raw" />
+      <remap from="depth_registered/image_rect" to="$(arg depth_registered_filtered)/hw_registered/image_rect_raw" />
       <remap from="depth_registered/points"     to="$(arg depth_registered)/points" />
     </node>
   </group>

--- a/launch/includes/manager.launch.xml
+++ b/launch/includes/manager.launch.xml
@@ -14,7 +14,7 @@
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <!-- Worker threads -->
   <arg name="num_worker_threads" />
-  
+
   <!-- Also globally disable bond heartbeat timeout in debug mode, so everything
        doesn't die when you hit a break point -->
   <param if="$(arg debug)" name="/bond_disable_heartbeat_timeout" value="true" />

--- a/launch/includes/processing.launch.xml
+++ b/launch/includes/processing.launch.xml
@@ -21,11 +21,12 @@
   <arg name="hw_registered_processing" default="true" />
   
   <!-- Remapping arguments -->
-  <arg name="rgb"              default="rgb" />
-  <arg name="ir"               default="ir" />
-  <arg name="depth"            default="depth" />
-  <arg name="depth_registered" default="depth_registered" />
-  <arg name="projector"        default="projector" />
+  <arg name="rgb"                       default="rgb" />
+  <arg name="ir"                        default="ir" />
+  <arg name="depth"                     default="depth" />
+  <arg name="depth_registered"          default="depth_registered" />
+  <arg name="depth_registered_filtered" default="depth_registered" />
+  <arg name="projector"                 default="projector" />
 
   <!-- RGB processing -->
   <include if="$(arg rgb_processing)"
@@ -55,13 +56,14 @@
   <!-- Depth-to-RGB registration and processing -->
   <include if="$(arg depth_registered_processing)"
            file="$(find rgbd_launch)/launch/includes/depth_registered.launch.xml">
-    <arg name="manager"                  value="$(arg manager)" />
-    <arg name="rgb"                      value="$(arg rgb)" />
-    <arg name="depth"                    value="$(arg depth)" />
-    <arg name="depth_registered"         value="$(arg depth_registered)" />
-    <arg name="respawn"                  value="$(arg respawn)" />
-    <arg name="sw_registered_processing" value="$(arg sw_registered_processing)" />
-    <arg name="hw_registered_processing" value="$(arg hw_registered_processing)" />
+    <arg name="manager"                   value="$(arg manager)" />
+    <arg name="rgb"                       value="$(arg rgb)" />
+    <arg name="depth"                     value="$(arg depth)" />
+    <arg name="depth_registered"          value="$(arg depth_registered)" />
+    <arg name="depth_registered_filtered" value="$(arg depth_registered_filtered)" />
+    <arg name="respawn"                   value="$(arg respawn)" />
+    <arg name="sw_registered_processing"  value="$(arg sw_registered_processing)" />
+    <arg name="hw_registered_processing"  value="$(arg hw_registered_processing)" />
   </include>
 
   <!-- Unregistered disparity image -->
@@ -76,12 +78,12 @@
   <!-- Registered disparity image -->
   <include if="$(arg disparity_registered_processing)"
            file="$(find rgbd_launch)/launch/includes/disparity_registered.launch.xml">
-    <arg name="manager"                  value="$(arg manager)" />
-    <arg name="depth_registered"         value="$(arg depth_registered)" />
-    <arg name="projector"                value="$(arg projector)" />
-    <arg name="respawn"                  value="$(arg respawn)" />
-    <arg name="sw_registered_processing" value="$(arg sw_registered_processing)" />
-    <arg name="hw_registered_processing" value="$(arg hw_registered_processing)" />
+    <arg name="manager"                   value="$(arg manager)" />
+    <arg name="depth_registered"          value="$(arg depth_registered)" />
+    <arg name="projector"                 value="$(arg projector)" />
+    <arg name="respawn"                   value="$(arg respawn)" />
+    <arg name="sw_registered_processing"  value="$(arg sw_registered_processing)" />
+    <arg name="hw_registered_processing"  value="$(arg hw_registered_processing)" />
   </include>
 
 </launch>


### PR DESCRIPTION
This enables the "injection" of a depth image filter into the middle of the rgbd processing pipeline. This is useful for efficiently removing known structure from the point cloud like a robotic manipulator.

It's done by defining the "depth_registered_filtered" argument, which then gets used by the point cloud processing node instead of the raw "depth_registered" topic.
