### PR TITLE
Add convert_metric nodes to depth_registered.launch.xml (Indigo)

### DIFF
--- a/launch/includes/depth_registered.launch.xml
+++ b/launch/includes/depth_registered.launch.xml
@@ -76,7 +76,7 @@
   </node>
 
   <!-- Unrectified depth image -->
-  <node pkg="nodelet" type="nodelet" name="$(arg depth)_metric"
+  <node pkg="nodelet" type="nodelet" name="$(arg depth_registered)_metric"
         args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
         respawn="$(arg respawn)">
     <remap from="image_raw" to="$(arg depth_registered)/image_raw" />

--- a/launch/includes/depth_registered.launch.xml
+++ b/launch/includes/depth_registered.launch.xml
@@ -66,6 +66,24 @@
       <remap from="depth_registered/image_rect" to="$(arg depth_registered)/hw_registered/image_rect_raw" />
       <remap from="depth_registered/points"     to="$(arg depth_registered)/points" />
     </node>
+
+  <!-- Rectified depth image -->
+  <node pkg="nodelet" type="nodelet" name="$(arg depth_registered)_metric_rect"
+        args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_raw" to="$(arg depth_registered)/image_rect_raw" />
+    <remap from="image"     to="$(arg depth_registered)/image_rect" />
+  </node>
+
+  <!-- Unrectified depth image -->
+  <node pkg="nodelet" type="nodelet" name="$(arg depth)_metric"
+        args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_raw" to="$(arg depth_registered)/image_raw" />
+    <remap from="image"     to="$(arg depth_registered)/image" />
+  </node>
+
+
   </group>
   
 </launch>


### PR DESCRIPTION
Tested successfully with ROS Indigo on Ubuntu 14.04

Note that the kinect does not work out of the box with the openni packages in Indigo, I had to follow the directions given here: http://www.pcl-users.org/Can-t-use-Kinect-in-Ubuntu14-04-tp4033666p4035318.html

Namely, compile and install Openni version 1.5.4.0 from https://github.com/OpenNI/OpenNI/releases and SensorKinect v0.93-5.1.2.1 from https://github.com/avin2/SensorKinect/releases

Fixes #11 
