### PR TITLE
[Travis CI] Update config to using industrial_ci with Prerelease Test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,31 @@
-sudo: required
-dist: trusty
-language: generic
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+      - gm130s@gmail.com
 env:
   matrix:
-    - ROS_DISTRO="indigo" DEB_REPOSITORY=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="indigo" DEB_REPOSITORY=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+    - ROS_DISTRO="indigo" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+    - ROS_DISTRO="jade"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="jade"   DEB_REPOSITORY=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="jade"   DEB_REPOSITORY=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="indigo" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - env: ROS_DISTRO="jade"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 install:
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c "echo \"deb ${DEB_REPOSITORY} `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-rosdep python-catkin-tools ros-${ROS_DISTRO}-catkin
-  - sudo rosdep init
-  - rosdep update
-script:
-  - mkdir -p ~/catkin_ws/src
-  - cd ~/catkin_ws
-  - ln -sf ${CI_SOURCE_PATH} src/${REPOSITORY_NAME}
-  - rosdep install --from-paths src -y --ignore-src --rosdistro ${ROS_DISTRO}
-  - source /opt/ros/${ROS_DISTRO}/setup.bash
-  - env | grep ROS
-  # Enable install space
-  - catkin config --install
-  # Build [and Install] packages
-  - catkin build --limit-status-rate 0.1 --no-notify -DCMAKE_BUILD_TYPE=Release
-  # Build tests
-  - catkin build --limit-status-rate 0.1 --no-notify --make-args tests
-  # Run tests
-  - catkin run_tests
-  # check test (this only works from ROS Indigo onward)
-  - catkin_test_results build
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config && source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
[industrial_ci](https://github.com/ros-industrial/industrial_ci) provides CI configs that can be commonly used, and intends to free ROS package maintainers from maintaining them. It also runs Prerelease Test for Indigo and Jade.
