### PR TITLE
add prefix to nodelet name

### DIFF
--- a/launch/includes/ir.launch.xml
+++ b/launch/includes/ir.launch.xml
@@ -8,7 +8,7 @@
   <arg name="ir" />
   
   <!-- Rectified image -->
-  <node pkg="nodelet" type="nodelet" name="rectify_ir"
+  <node pkg="nodelet" type="nodelet" name="$(arg ir)_rectify_ir"
         args="load image_proc/rectify $(arg manager) $(arg bond)"
         respawn="$(arg respawn)">
     <remap from="image_mono" to="$(arg ir)/image_raw" />

--- a/launch/includes/rgb.launch.xml
+++ b/launch/includes/rgb.launch.xml
@@ -13,7 +13,7 @@
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
 
   <!-- Debayered images -->
-  <node if="$(arg debayer_processing)" pkg="nodelet" type="nodelet" name="debayer"
+  <node if="$(arg debayer_processing)" pkg="nodelet" type="nodelet" name="$(arg rgb)_debayer"
         args="load image_proc/debayer $(arg manager) $(arg bond)"
         respawn="$(arg respawn)">
     <remap from="image_raw"   to="$(arg rgb)/image_raw" />
@@ -22,7 +22,7 @@
   </node>
 
   <!-- Monochrome rectified image -->
-  <node if="$(arg debayer_processing)" pkg="nodelet" type="nodelet" name="rectify_mono"
+  <node if="$(arg debayer_processing)" pkg="nodelet" type="nodelet" name="$(arg rgb)_rectify_mono"
         args="load image_proc/rectify $(arg manager) $(arg bond)"
         respawn="$(arg respawn)">
     <remap from="image_mono" to="$(arg rgb)/image_mono" />
@@ -30,7 +30,7 @@
   </node>
 
   <!-- Color rectified image -->
-  <node pkg="nodelet" type="nodelet" name="rectify_color"
+  <node pkg="nodelet" type="nodelet" name="$(arg rgb)_rectify_color"
         args="load image_proc/rectify $(arg manager) $(arg bond)"
         respawn="$(arg respawn)">
     <remap if="$(arg debayer_processing)" from="image_mono" to="$(arg rgb)/image_color" />


### PR DESCRIPTION
To work with robots with more than 2 rgb cameras, we have to avoid conflicts of each nodelet names.
In `depth.launch.xml`, `disparity.launch.xml`, nodelet names are already defined with prefix, so I added prefix also to `rgb.launch.xml` same as other include launch files.
