### PR TITLE
Add respawn arg to manager launch

### DIFF
--- a/launch/includes/manager.launch.xml
+++ b/launch/includes/manager.launch.xml
@@ -20,7 +20,7 @@
   <!-- Nodelet manager -->
   <node pkg="nodelet" type="nodelet" name="$(arg name)" args="manager"
         output="screen" launch-prefix="$(arg launch_prefix)"
-        respawn="$(arg respawn">
+        respawn="$(arg respawn)">
      <param name="num_worker_threads" value="$(arg num_worker_threads)" />
   </node>
 

--- a/launch/includes/manager.launch.xml
+++ b/launch/includes/manager.launch.xml
@@ -10,6 +10,8 @@
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <!-- Worker threads -->
   <arg name="num_worker_threads" />
+  
+  <arg name="respawn" default="false" />
 
   <!-- Also globally disable bond heartbeat timeout in debug mode, so everything
        doesn't die when you hit a break point -->
@@ -17,7 +19,8 @@
 
   <!-- Nodelet manager -->
   <node pkg="nodelet" type="nodelet" name="$(arg name)" args="manager"
-        output="screen" launch-prefix="$(arg launch_prefix)">
+        output="screen" launch-prefix="$(arg launch_prefix)"
+        respawn="$(arg respawn">
      <param name="num_worker_threads" value="$(arg num_worker_threads)" />
   </node>
 


### PR DESCRIPTION
defaults to false, so no change with existing use. Without this, setting nodelets to respawn is of limited utility in case of a crash, as the manager does not respawn (unless I'm missing something).