### PR TITLE
Noetic support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - env: ROS_DISTRO="melodic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
     - env: ROS_DISTRO="noetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 before_script:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone https://github.com/ros-industrial/industrial_ci.git -b master .ci_config
 script:
   - source .ci_config/travis.sh
 #  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # This config file for Travis CI utilizes ros-industrial/industrial_ci package.
 # For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
 sudo: required 
-dist: trusty 
+dist: xenial
 services:
   - docker
 language: generic 
@@ -15,24 +15,21 @@ notifications:
       - gm130s@gmail.com
 env:
   matrix:
-    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
-    - ROS_DISTRO="jade"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
     - ROS_DISTRO="kinetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
-    - ROS_DISTRO="lunar" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+    - ROS_DISTRO="melodic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO="noetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="noetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
+    - ROS_DISTRO="noetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 matrix:
   allow_failures:
     # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
-    - env: ROS_DISTRO="jade"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
     - env: ROS_DISTRO="kinetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
-    # As of 20170415 ROS Lunar and many dependency aren't ready yet. Once this gets cleared we may want to remove some of the following entries.
-    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
-    - env: ROS_DISTRO="lunar" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - env: ROS_DISTRO="melodic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - env: ROS_DISTRO="noetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 before_script:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # This config file for Travis CI utilizes ros-industrial/industrial_ci package.
 # For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
 sudo: required 
-dist: xenial
 services:
   - docker
 language: generic 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ notifications:
 env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
     - ROS_DISTRO="kinetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
     - ROS_DISTRO="melodic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
     - ROS_DISTRO="noetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
-    - ROS_DISTRO="noetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu  USE_DEB=true
     - ROS_DISTRO="noetic" PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
 matrix:
   allow_failures:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rgbd_launch)
 
 find_package(catkin)


### PR DESCRIPTION
Addresses https://github.com/ros-drivers/rgbd_launch/issues/48

# Branch
- Based off of `jade-devel` (which is used for up to [ROS Melodic release](https://github.com/ros/rosdistro/blob/8b9be633f139711620a4ba8e239874ac0ae063b9/melodic/distribution.yaml#L8254))
- Target: `noetic-devel` (which I just branched off of `jade-devel`).

# CoS
- [ ] CI cnofig update. CI should pass.
