### PR TITLE
Sync noetic to indigo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ install(PROGRAMS scripts/hydro-upgrade-notice
 
 if(CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  find_package(rostest REQUIRED) 
+  find_package(rostest REQUIRED)
   roslaunch_add_file_check(launch)
   roslaunch_add_file_check(test)
-  add_rostest(test/camera.test) 
+  add_rostest(test/camera.test)
 endif()

--- a/package.xml
+++ b/package.xml
@@ -27,5 +27,6 @@
   <run_depend>nodelet</run_depend>
   <run_depend>tf2_ros</run_depend>
 
-  <test_depend>rostest</test_depend>test_depend> 
+  <test_depend>rostest</test_depend>
+
 </package>

--- a/test/camera.test
+++ b/test/camera.test
@@ -1,6 +1,12 @@
 <launch>
   <include file="$(find rgbd_launch)/test/camera_for_test.launch" />
 
-  <test test-name="test_kinect_frames"
-        pkg="rgbd_launch" type="test_rgbd_launch.py" />
+  <test pkg="rostest" type="hztest" name="hztest_tf" test-name="hztest_tf">
+    <param name="topic" value="tf" />  
+    <param name="hz" value="40.0" />
+    <param name="hzerror" value="10.0" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="30.0" />
+  </test>
+
 </launch>


### PR DESCRIPTION
# Issue aimed at
[noetic-devel](https://github.com/ros-drivers/rgbd_launch/tree/noetic-devel) branch shows 38 commits ahead, 30 commits behind `indigo-devel`, the current main branch. Since `indigo-devel` is way EoL and only `noetic-devel` should be active for now, fixing the outdated `noetic-devel` by pulling unmerged commits from indigo.

# Added changes
Cherry-picked the following unless noted. A lot of cherry-picking turned out empty though.
- #25
- #27 is passed on as #30 reverts it.
- #29
- #31
- #28
- #34 skipped as it seems for indigo-devel
- #44